### PR TITLE
Add setuptools support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 dictionary.dic
 *.pyc
 *.env
+*.egg-info
+dist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,11 +9,6 @@ authors = [
     {name = "Commandcracker"},
 ]
 description = "A server which provides a WebSocket API for YouCube clients"
-urls = {
-    Homepage = "https://youcube.madefor.cc"
-    Repository = "https://github.com/CC-YouCube/server"
-    Documentation = "https://youcube.madefor.cc/guides/server/installation/"
-}
 readme = "README.md"
 requires-python = ">=3.7"
 keywords = ["youtube", "youcube", "computercraft", "minecraft"]
@@ -27,6 +22,11 @@ classifiers = [
 ]
 # Required for pulling dependencies from requirements.txt
 dynamic = ["dependencies"]
+
+[project.urls]
+Homepage = "https://youcube.madefor.cc"
+Repository = "https://github.com/CC-YouCube/server"
+Documentation = "https://youcube.madefor.cc/guides/server/installation/"
 
 [tool.setuptools.dynamic]
 # Pull dependencies from requirements.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,41 @@
+[build-system]
+requires = ["setuptools", "setuptools-scm"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "youcube-server"
+version = "1.0.0"
+authors = [
+    {name = "Commandcracker"},
+]
+description = "A server which provides a WebSocket API for YouCube clients"
+urls = {
+    Homepage = "https://youcube.madefor.cc"
+    Repository = "https://github.com/CC-YouCube/server"
+    Documentation = "https://youcube.madefor.cc/guides/server/installation/"
+}
+readme = "README.md"
+requires-python = ">=3.7"
+keywords = ["youtube", "youcube", "computercraft", "minecraft"]
+license = {text = "GPL-3.0"}
+classifiers = [
+	"Programming Language :: Python :: 3",
+	"License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+	"Natural Language :: English",
+	"Topic :: Multimedia :: Video",
+	"Topic :: Multimedia :: Sound/Audio :: Players",
+]
+# Required for pulling dependencies from requirements.txt
+dynamic = ["dependencies"]
+
+[tool.setuptools.dynamic]
+# Pull dependencies from requirements.txt
+dependencies = {file = ["src/requirements.txt"]}
+
+[tool.setuptools.packages.find]
+where = ["src"]  # list of folders that contain the packages (["."] by default)
+include = ["youcube*"]  # package names should match these glob patterns (["*"] by default)
+
 [tool.autopep8]
 ignore = "E701"
+


### PR DESCRIPTION
# Description

This allows for packaging this into a .whl, which is required for Nix packaging.

I went ahead and added it to the preexisting `pyproject.toml`.

As a side effect, this could simplify publishing to `pip` or other package managers as well.

This pull request is part of a series of pull requests that aim to simplify Nix packaging.

## Type of change

Please delete options that are not relevant.

- [x] Other: chore

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Run `pip install build && python3 -m build && python3 -m build --sdist` in the repository's root to build a wheel and a `.tar`, which both contain the application.

**Test Configuration**:

Please delete options that are not relevant.

- Python: Tested on all versions from 3.7 to 3.11
- OS: Linux Mint Uma

## Checklist

- [x] My code follows the style guidelines of this project (all lints have passed)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
