### PR TITLE
Use `/usr/bin/env python3` in all scripts

### DIFF
--- a/spellcheck_wordlist.txt
+++ b/spellcheck_wordlist.txt
@@ -16,6 +16,7 @@ YouCube
 Spotify
 
 # Programming Keywords
+env
 untrusted
 usr
 utf

--- a/src/Dockerfile.nvidia
+++ b/src/Dockerfile.nvidia
@@ -7,6 +7,7 @@ ENV SANJUUNI_VERSION=0.4
 ARG SANJUUNI_SHA512SUM="952a6c608d167f37faad53ee7f2e0de8090a02bf73b6455fae7c6b6f648dd6a188e7749fe26caeee85126b2a38d7391389c19afb0100e9962dc551188b9de6ae *sanjuuni.tar.gz"
 
 RUN set -eux; \
+    apt-get update; \
     apt-get install \
     ocl-icd-opencl-dev \
     wget \
@@ -32,6 +33,7 @@ COPY requirements.txt .
 COPY youcube /youcube
 
 RUN set -eux; \
+    apt-get update; \
     apt-get install \
     libpoco-dev \
     python3-pip \

--- a/src/compile.py
+++ b/src/compile.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 """

--- a/src/youcube/__main__.py
+++ b/src/youcube/__main__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 """

--- a/src/youcube/yc_colours.py
+++ b/src/youcube/yc_colours.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 """

--- a/src/youcube/yc_download.py
+++ b/src/youcube/yc_download.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 """

--- a/src/youcube/yc_logging.py
+++ b/src/youcube/yc_logging.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 """

--- a/src/youcube/yc_magic.py
+++ b/src/youcube/yc_magic.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 """

--- a/src/youcube/yc_spotify.py
+++ b/src/youcube/yc_spotify.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 """

--- a/src/youcube/yc_utils.py
+++ b/src/youcube/yc_utils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 """

--- a/src/youcube/youcube.py
+++ b/src/youcube/youcube.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 """


### PR DESCRIPTION
# Description

It is best-practice to use `/usr/bin/env` when calling scripting language interpreters, such as python. This allows the user to:

1) Take advantage of virtual environments and environment-management
   tools such as asdf.
2) Have python3 at a nonstandard path but still located on $PATH.

Nix also strongly requires using this convention due to Python being installed into the Nix store instead of `/usr/bin`.

This pull request is part of a series of pull requests that aim to simplify Nix packaging.

## Type of change

Please delete options that are not relevant.

- [x] Other: chore/cleanup

## How Has This Been Tested?

All files should be executable per normal.

**Test Configuration**:

Please delete options that are not relevant.

- Python: All Pythons from 3.7 to 3.11.

## Checklist

- [x] My code follows the style guidelines of this project (all lints have passed)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
